### PR TITLE
docs:[ produce] replace two broken link

### DIFF
--- a/content/how-to/produce/send-delay-event.md
+++ b/content/how-to/produce/send-delay-event.md
@@ -11,8 +11,8 @@ The following document will teach you how to build a simple producer with a time
 **Prerequisites**
 
 To send events to Vanus, you must meet the following prerequisites:
-1. Have a running [Vanus](https://github.com/linkall-labs/docs/blob/main/user-manual/getting-started/install/k8s(recommended).md) cluster.
-2. Have [vsctl](https://github.com/linkall-labs/docs/blob/main/user-manual/how-to/vsctl.md).
+1. Have a running [Vanus](https://github.com/linkall-labs/docs/blob/main/content/getting-started/installation.mdx) cluster.
+2. Have [vsctl](https://github.com/linkall-labs/docs/blob/main/content/how-to/vsctl.md).
 3. Have created an [Eventbus](https://github.com/linkall-labs/docs/blob/main/concepts/eventbus.md) named quick-start.
 4. Have exported the environment variable by running this command: `export VANUS_GATEWAY=127.0.0.1:8080`.
 

--- a/content/how-to/produce/send-delay-event.md
+++ b/content/how-to/produce/send-delay-event.md
@@ -12,7 +12,7 @@ The following document will teach you how to build a simple producer with a time
 
 To send events to Vanus, you must meet the following prerequisites:
 1. Have a running [Vanus](/getting-started/installation) cluster.
-2. Have [vsctl](https://github.com/linkall-labs/docs/blob/main/content/how-to/vsctl.md).
+2. Have [vsctl](/how-to/vsctl).
 3. Have created an [Eventbus](https://github.com/linkall-labs/docs/blob/main/concepts/eventbus.md) named quick-start.
 4. Have exported the environment variable by running this command: `export VANUS_GATEWAY=127.0.0.1:8080`.
 

--- a/content/how-to/produce/send-delay-event.md
+++ b/content/how-to/produce/send-delay-event.md
@@ -11,7 +11,7 @@ The following document will teach you how to build a simple producer with a time
 **Prerequisites**
 
 To send events to Vanus, you must meet the following prerequisites:
-1. Have a running [Vanus](https://github.com/linkall-labs/docs/blob/main/content/getting-started/installation.mdx) cluster.
+1. Have a running [Vanus](/getting-started/installation) cluster.
 2. Have [vsctl](https://github.com/linkall-labs/docs/blob/main/content/how-to/vsctl.md).
 3. Have created an [Eventbus](https://github.com/linkall-labs/docs/blob/main/concepts/eventbus.md) named quick-start.
 4. Have exported the environment variable by running this command: `export VANUS_GATEWAY=127.0.0.1:8080`.


### PR DESCRIPTION
Signed-off-by: Shivam Sharma <meshivam81@gmail.com>

<!--
Thank you for contributing to Vanus Documentation!
PR Title Format: 
style/docs/ci/chore/...: what's changed
Note: see https://github.com/linkall-labs/docs/blob/main/CONTRIBUTING.md#commit-message-style to know more about title format
-->

### Related Issue

Solving Issue: #209 

### PR Summary
 Replace two links in the `Send an event with delay `  

### PR Type

<!-- At least one of them should be chosen. 
It's recommended to solve only one problem in each PR.
-->

- [ ] Fix typos or format(punctuation, space, indentation, code block, etc.)
- [ ] Update inappropriate or misunderstanding content
- [x] Add missing content or new documents
- [ ] Delete useless content or outdated documents
- [ ] Localize or translate documents
- [ ] Deal with GitHub action files and scripts
- [ ] Deal with chores