### PR TITLE
Replaced Links in how to use lambda.md

### DIFF
--- a/content/how-to/use-lambda.md
+++ b/content/how-to/use-lambda.md
@@ -6,8 +6,8 @@ Vanus supports sending direct events to  [AWS Lambda][lambda]. The following pag
 
 Before using Lambda, you must meet the following prerequisites:
 
-1. Have a running [Vanus](https://github.com/linkall-labs/docs/blob/main/user-manual/getting-started/install/k8s(recommended).md) cluster.
-2. Have [vsctl](https://github.com/linkall-labs/docs/blob/main/user-manual/how-to/vsctl.md).
+1. Have a running [Vanus](https://github.com/linkall-labs/docs/blob/main/content/getting-started/installation.mdx) cluster.
+2. Have [vsctl](https://github.com/linkall-labs/docs/blob/main/content/how-to/vsctl.md).
 3. An AWS account configured with [Access Keys][access-keys].
 4. Have a [Lambda function][lambda function]
 5. The "lambda:InvokeFunction" [permission] grant for your AWS user account


### PR DESCRIPTION
docs: changed links of [vanus] and [vsctl]. I have changed links as per raised issue # 201.  here is the issue (https://github.com/linkall-labs/docs/issues/201)

<!--
Thank you for contributing to Vanus Documentation!
PR Title Format: 
style/docs/ci/chore/...: what's changed
Note: see https://github.com/linkall-labs/docs/blob/main/CONTRIBUTING.md#commit-message-style to know more about title format
-->

### Related Issue

Solving Issue: #201 

### PR Summary

This pull request will make changes to content/how-to/use-lambda.md. which will 
<!--Briefly tell us what does this PR do?-->

### PR Type

<!-- At least one of them should be chosen. 
It's recommended to solve only one problem in each PR.
-->

- [ ] Fix typos or format(punctuation, space, indentation, code block, etc.)
- [ ] Update inappropriate or misunderstanding content
-  Add missing content or new documents
- [ ] Delete useless content or outdated documents
- [ ] Localize or translate documents
- [ ] Deal with GitHub action files and scripts
- [ ] Deal with chores